### PR TITLE
Build and fix .net 8 project

### DIFF
--- a/src/AlbionOnlineSniffer.Web/Program.cs
+++ b/src/AlbionOnlineSniffer.Web/Program.cs
@@ -23,7 +23,7 @@ builder.Services.AddRouting();
 builder.Services.AddSingleton<EventStreamService>();
 
 // Core services
-Core.DependencyProvider.RegisterServices(builder.Services);
+AlbionOnlineSniffer.Core.DependencyProvider.RegisterServices(builder.Services);
 
 // Packet capture service with DI logger
 builder.Services.AddSingleton<PacketCaptureService>(sp =>
@@ -79,7 +79,7 @@ using (var scope = app.Services.CreateScope())
 	}
 
 	// Verificar offsets carregados
-	var packetOffsets = services.GetRequiredService<Core.Models.ResponseObj.PacketOffsets>();
+	var packetOffsets = services.GetRequiredService<AlbionOnlineSniffer.Core.Models.ResponseObj.PacketOffsets>();
 	logger.LogInformation("🔍 VERIFICANDO OFFSETS CARREGADOS (via Core):");
 	logger.LogInformation("  - Leave: [{Offsets}]", string.Join(", ", packetOffsets.Leave));
 	logger.LogInformation("  - HealthUpdateEvent: [{Offsets}]", string.Join(", ", packetOffsets.HealthUpdateEvent));


### PR DESCRIPTION
Correct ambiguous namespace references in `Program.cs` to fix build errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-dddf228f-c299-455d-b910-51815acf403c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dddf228f-c299-455d-b910-51815acf403c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

